### PR TITLE
Python: Update shebang line

### DIFF
--- a/plexdupes.py
+++ b/plexdupes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 import collections
 import logging
 import os


### PR DESCRIPTION
Fixes errors on Python versions higher than 3.5

```
/usr/bin/env: 'python3.5': No such file or directory
```