### PR TITLE
Fail gracefully on unsupported library type

### DIFF
--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -48,26 +48,37 @@ except:
 
 
 def get_dupes(plex_section_name):
+
+    supported_section_types = ('episode', 'movie')
+
     sec_type = get_section_type(plex_section_name)
-    dupe_search_results = plex.library.section(plex_section_name).search(duplicate=True, libtype=sec_type)
-    dupe_search_results_new = dupe_search_results.copy()
 
-    # filter out duplicates that do not have exact file path/name
-    if cfg.FIND_DUPLICATE_FILEPATHS_ONLY:
-        for dupe in dupe_search_results:
-            if not all(x == dupe.locations[0] for x in dupe.locations):
-                dupe_search_results_new.remove(dupe)
+    if sec_type in supported_section_types:
+        dupe_search_results = plex.library.section(plex_section_name).search(duplicate=True, libtype=sec_type)
+        dupe_search_results_new = dupe_search_results.copy()
 
-    return dupe_search_results_new
+        # filter out duplicates that do not have exact file path/name
+        if cfg.FIND_DUPLICATE_FILEPATHS_ONLY:
+            for dupe in dupe_search_results:
+                if not all(x == dupe.locations[0] for x in dupe.locations):
+                    dupe_search_results_new.remove(dupe)
+    else:
+        log.warning("Section '%s' of type '%s' is not supported" % (plex_section_name, sec_type))
+        print("Section '%s' of type '%s' is not supported" % (plex_section_name, sec_type))
+
+    return dupe_search_results_new if sec_type in supported_section_types else list()        
 
 
-def get_section_type(plex_section_name):
-    try:
+def get_section_type(plex_section_name):                                                         
+    try:                                                                                                      
         plex_section_type = plex.library.section(plex_section_name).type
-    except Exception:
+    except Exception:                                                             
         log.exception("Exception occurred while trying to lookup the section type for Library: %s", plex_section_name)
-        exit(1)
-    return 'episode' if plex_section_type == 'show' else 'movie'
+        exit(1)                                                                                                       
+                                                                                                                      
+    if plex_section_type == 'show': plex_section_type = 'episode'                 
+                                                                                                     
+    return plex_section_type
 
 
 def get_score(media_info):


### PR DESCRIPTION
In the event that a library type is not 'show' or 'movie', fail gracefully instead of causing an exception.

## Before:

```
       _                 _                   __ _           _
 _ __ | | _____  __   __| |_   _ _ __   ___ / _(_)_ __   __| | ___ _ __
| '_ \| |/ _ \ \/ /  / _` | | | | '_ \ / _ \ |_| | '_ \ / _` |/ _ \ '__|
| |_) | |  __/>  <  | (_| | |_| | |_) |  __/  _| | | | | (_| |  __/ |
| .__/|_|\___/_/\_\  \__,_|\__,_| .__/ \___|_| |_|_| |_|\__,_|\___|_|
|_|                             |_|

#########################################################################
# Author:   l3uddz                                                      #
# URL:      https://github.com/l3uddz/plex_dupefinder                   #
# --                                                                    #
#         Part of the Cloudbox project: https://cloudbox.works          #
#########################################################################
#                   GNU General Public License v3.0                     #
#########################################################################

Initialized
Finding dupes...
Found 0 dupes for section 'Movies'
Found 2 dupes for section 'TV'
Traceback (most recent call last):
  File "/usr/local/bin/plex_dupefinder", line 354, in <module>
    dupes = get_dupes(section)
  File "/usr/local/bin/plex_dupefinder", line 52, in get_dupes
    dupe_search_results = plex.library.section(plex_section_name).search(duplicate=True, libtype=sec_type)
  File "/usr/lib/python3.8/site-packages/plexapi/library.py", line 504, in search
    args[category] = self._cleanSearchFilter(category, value, libtype)
  File "/usr/lib/python3.8/site-packages/plexapi/library.py", line 528, in _cleanSearchFilter
    raise BadRequest('Unknown filter category: %s' % category)
plexapi.exceptions.BadRequest: Unknown filter category: duplicate
```

## After:

```
       _                 _                   __ _           _
 _ __ | | _____  __   __| |_   _ _ __   ___ / _(_)_ __   __| | ___ _ __
| '_ \| |/ _ \ \/ /  / _` | | | | '_ \ / _ \ |_| | '_ \ / _` |/ _ \ '__|
| |_) | |  __/>  <  | (_| | |_| | |_) |  __/  _| | | | | (_| |  __/ |
| .__/|_|\___/_/\_\  \__,_|\__,_| .__/ \___|_| |_|_| |_|\__,_|\___|_|
|_|                             |_|

#########################################################################
# Author:   l3uddz                                                      #
# URL:      https://github.com/l3uddz/plex_dupefinder                   #
# --                                                                    #
#         Part of the Cloudbox project: https://cloudbox.works          #
#########################################################################
#                   GNU General Public License v3.0                     #
#########################################################################

Initialized
Finding dupes...
Found 0 dupes for section 'Movies'
Found 3 dupes for section 'TV'
Section 'Music' of type 'artist' is not supported
Found 0 dupes for section 'Music'

...
```