### PR TITLE
Fix for python_tabulate's handlings of commas

### DIFF
--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -303,7 +303,7 @@ def build_tabulated(parts, items):
             if 'choice' in k:
                 tmp.append(choice)
             elif 'score' in k:
-                tmp.append(format(parts[item_id][k], ',d'))
+                tmp.append(format(parts[item_id][k], 'd'))
             elif 'id' in k:
                 tmp.append(parts[item_id][k])
             elif 'file' in k:


### PR DESCRIPTION
python_tabulate 0.8.8 chokes on comma characters when converting strings to floats; see https://github.com/astanin/python-tabulate/issues/114 ; this causes the script to fail when printing tables of dupes to stdout for the user to select which file to 'keep'.

Simply dropping the ',' from the score value resolves this and is of negligible cosmetic value.