### PR TITLE
Feature/add 2fa clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,17 @@ The scoring is based on: non-configurable and configurable parameters.
 - The default settings should be sufficient for most.
 
 
+## Choise Config File (optional)
+
+- You can choice specific config file by --config argument.
+
+- Example:
+
+```plex_dupefinder --config=config2.json```
+
+- The default value is config.json
+
+
 # Plex
 
 You will need to make sure that **Allow media deletion** is enabled in Plex.

--- a/README.md
+++ b/README.md
@@ -100,13 +100,15 @@ _Note: Steps below are for Debian-based distros (other operating systems will re
    plex_dupefinder
    ```
 
-1. Fill in Plex URL and credentials at the prompt to generated a Plex Access Token (optional).
+1. Fill in Plex URL and credentials at the prompt to generated a Plex Access Token (optional).  
+
+    If you are using Two Factor Authentication then append your 2FA code to the end of your password.  For example, if you password was "Let9MeIn" and you had the 2FA code "444 321" on your Authenticator app you should enter "Let9MeIn444321" as your password.
 
    ```
    Dumping default config to: /opt/plex_dupefinder/config.json
    Plex Server URL: http://localhost:32400
    Plex Username: your_plex_username
-   Plex Password: your_plex_password
+   Plex Password (Using 2FA?  Append your 2FA code to your password to obtain your token): your_plex_password
    Auto Delete duplicates? [y/n]: n
    Please edit the default configuration before running again!
    ```

--- a/config.py
+++ b/config.py
@@ -9,7 +9,11 @@ from attrdict import AttrDict
 from plexapi.myplex import MyPlexAccount
 from getpass import getpass
 
-config_path = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), 'config.json')
+parser = argparse.ArgumentParser(description='plex_dupefinder')
+parser.add_argument('--config', dest='config', default=os.path.dirname(os.path.realpath(sys.argv[0]))+'/config.json', help='set custom config location')
+args = parser.parse_args()
+
+config_path = os.path.join(os.path.dirname(os.path.realpath(args.config)), os.path.split(args.config)[1])
 base_config = {
     'PLEX_SERVER': 'https://plex.your-server.com',
     'PLEX_TOKEN': '',

--- a/config.py
+++ b/config.py
@@ -102,7 +102,7 @@ def build_config():
 
         # Get Credentials for plex.tv
         user = input("Plex Username: ")
-        password = getpass('Plex Password: ')
+        password = getpass('Plex Password (Using 2FA?  Append your 2FA code to your password to obtain your token): ')
 
         # Get choice for Auto Deletion
         auto_del = input("Auto Delete duplicates? [y/n]: ")

--- a/deletefiles.sh
+++ b/deletefiles.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Since plex is having such great troubles deleting files I wrote this little bash script to read the decisions.log and delete the files after it's been run.
+
+inputfile=$1
+while read -r line
+do
+          if [[ "$line" == *"Removing : {"* ]]; then
+             var=$(echo "${line}" | grep Removing | sed 's/^.*\(file.*multipart\).*$/\1/' | sed -r 's/^.{9}//' | sed 's/.\{14\}$//')
+             rm "${var}"
+          fi
+done < "$inputfile"

--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -303,7 +303,7 @@ def build_tabulated(parts, items):
             if 'choice' in k:
                 tmp.append(choice)
             elif 'score' in k:
-                tmp.append(format(parts[item_id][k], ',d'))
+                tmp.append(str(format(parts[item_id][k], ',d')))
             elif 'id' in k:
                 tmp.append(parts[item_id][k])
             elif 'file' in k:


### PR DESCRIPTION
Like many, I now use Two Factor Authentication with Plex (2FA).

In order to login and get an API token from an application such as plex_dupefinder, you ned to know the "workaround" of adding your 2FA code at the end of the password.  Source: https://unraid-guides.com/2021/01/31/how-to-connect-plex-to-apps-that-dont-support-two-factor-authentication-2fa/

This change will add clarification to README.md and to the prompts from config.py