### PR TITLE
Small change to primary script

### DIFF
--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -221,7 +221,7 @@ def write_decision(title=None, keeping=None, removed=None):
     if removed:
         lines.append('\tRemoving : %r\n' % removed)
 
-    with open(decision_filename, 'a') as fp:
+    with open(decision_filename, 'a' encoding="utf-8") as fp:
         fp.writelines(lines)
     return
 

--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -221,7 +221,7 @@ def write_decision(title=None, keeping=None, removed=None):
     if removed:
         lines.append('\tRemoving : %r\n' % removed)
 
-    with open(decision_filename, 'a' encoding="utf-8") as fp:
+    with open(decision_filename, 'a', encoding="utf-8") as fp:
         fp.writelines(lines)
     return
 


### PR DESCRIPTION
Fixed an issue on line #224

--Replaced code--
with open(decision_filename, 'a') as fp:
        fp.writelines(lines)
    return

--replacement code--
with open(decision_filename, 'a', encoding="utf-8") as fp:
        fp.writelines(lines)
    return


Traceback (most recent call last):
  File "C:\Users\Admin\Desktop\DupeFinder\venv\Scripts\plex_dupefinder.py", line 448, in <module>
    write_decision(keeping=part_info)
  File "C:\Users\Admin\Desktop\DupeFinder\venv\Scripts\plex_dupefinder.py", line 225, in write_decision
    fp.writelines(lines)
  File "C:\Users\Admin\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 234-245: character maps to <undefined>