### PR TITLE
Message user about library not existing

### DIFF
--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -66,6 +66,7 @@ def get_section_type(plex_section_name):
         plex_section_type = plex.library.section(plex_section_name).type
     except Exception:
         log.exception("Exception occurred while trying to lookup the section type for Library: %s", plex_section_name)
+        print(f'Error accessing library "{plex_section_name}" - Does this library specified in the config exist on the Plex server?')
         exit(1)
     return 'episode' if plex_section_type == 'show' else 'movie'
 


### PR DESCRIPTION
The initial default config file specifies library "TV" but mine was called "TV Shows" which caused an error when "TV" was attempted to be accessed. Messaging the user is a friendly way letting them know why the script has exited.