### PR TITLE
Update plex_dupefinder.py - fix no episode number

### DIFF
--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -348,6 +348,11 @@ if __name__ == "__main__":
         # loop returned duplicates
         for item in dupes:
             if item.type == 'episode':
+                if item.index == None:
+                  #print(f"error on {item.seasonEpisode} of {item.grandparentTitle} - no item index")
+                  title = "%s - %02dx%02d - %s" % (
+                    item.grandparentTitle, int(item.parentIndex), -1, item.title)
+                  continue
                 title = "%s - %02dx%02d - %s" % (
                     item.grandparentTitle, int(item.parentIndex), int(item.index), item.title)
             elif item.type == 'movie':


### PR DESCRIPTION
fix https://github.com/l3uddz/plex_dupefinder/issues/76

Error processing unattributed TV episode:
```
  File "C:\git\plex_dupefinder\plex_dupefinder.py", line 353, in <module>
    item.grandparentTitle, int(item.parentIndex), int(item.index), item.title)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

The above errors happens when an episode is encountered that does not have season/episode number attribution. Example:
```
<Episode:81092:Animals-Unscripted-s2024eNone>
```

Not much can be done by dupefinder since there is no episode attribution. Decided against printing or logging an exception.
